### PR TITLE
Fix short-key notation for optional arguments

### DIFF
--- a/spec/cliargs_parsing_spec.lua
+++ b/spec/cliargs_parsing_spec.lua
@@ -109,6 +109,14 @@ describe("Testing cliargs library parsing commandlines", function()
     assert.are.same(result, defaults)
   end)
 
+  it("tests option using -short-key value notation", function()
+    _G.arg = { "-out", "outfile" }
+    cli:add_opt("-out VALUE", "output file")
+    defaults = { out = "outfile" }
+    result = cli:parse()
+    assert.are.same(result, defaults)
+  end)
+
   it("tests optional using --expanded-key notation, --x=VALUE", function()
     _G.arg = { "--compress=lzma" }
     defaults = populate_optionals(cli)
@@ -156,7 +164,7 @@ describe("Testing cliargs library parsing commandlines", function()
     result = cli:parse()
     assert.are.same(result, defaults)
   end)
-    
+
   it("tests ek-only flag", function()
     _G.arg = { "--verbose" }
     defaults = populate_flags(cli)

--- a/src/cliargs.lua
+++ b/src/cliargs.lua
@@ -77,11 +77,11 @@ local function disect(key)
   local k, ek, v
   local dummy
   -- if there is no comma, between short and extended, add one
-  _, _, dummy = key:find("^%-([%a%d])[%s]%-%-")
+  _, _, dummy = key:find("^%-([%a%d]+)[%s]%-%-")
   if dummy then key = key:gsub("^%-[%a%d][%s]%-%-", "-"..dummy..", --", 1) end
   -- for a short key + value, replace space by "="
-  _, _, dummy = key:find("^%-([%a%d])[%s]")
-  if dummy then key = key:gsub("^%-([%a%d])[ ]", "-"..dummy.."=", 1) end
+  _, _, dummy = key:find("^%-([%a%d]+)[%s]")
+  if dummy then key = key:gsub("^%-([%a%d]+)[ ]", "-"..dummy.."=", 1) end
   -- if there is no "=", then append one
   if not key:find("=") then key = key .. "=" end
   -- get value


### PR DESCRIPTION
This fixes short-key notation for optional arguments when they are of the form `-sk VALUE`, such that
```lua
cli:add_opt("-sk VALUE", "short-key description")
```
will not generate an error.

Without this fix the following error would be generated:
```
$ app.lua -sk value
error: unknown/bad flag; -sk; re-run with --help for usage
```
