### PR TITLE
Specifiying an option multiple times inserts to a list

### DIFF
--- a/spec/cliargs_parsing_spec.lua
+++ b/spec/cliargs_parsing_spec.lua
@@ -131,6 +131,17 @@ describe("Testing cliargs library parsing commandlines", function()
     assert.are.same(result, defaults)
   end)
 
+  it("tests optional using multiple keys specified", function()
+    _G.arg = { "--key", "value1", "-k", "value2", "--key=value3" }
+    cli:add_option("-k, --key=VALUE", "key that can be specified multiple times", {})
+    defaults = { key = {"value1", "value2", "value3"} }
+    defaults.k = defaults.key
+
+    result = cli:parse()
+
+    assert.are.same(result, defaults)
+  end)
+
   it("tests flag using -short-key notation", function()
     _G.arg = { "-v" }
     defaults = populate_flags(cli)

--- a/src/cliargs.lua
+++ b/src/cliargs.lua
@@ -211,7 +211,7 @@ function cli:add_opt(key, desc, default)
   -- 8. --expanded=VALUE
 
   assert(type(key) == "string" and type(desc) == "string", "Key and description are mandatory arguments (Strings)")
-  assert(type(default) == "string" or default == nil or default == false, "Default argument: expected a string or nil")
+  assert(type(default) == "string" or default == nil or default == false or (type(default) == "table" and next(default) == nil), "Default argument: expected a string, nil, or {}")
 
   local k, ek, v = disect(key)
 
@@ -350,7 +350,11 @@ function cli:parse(noprint, dump)
       end
     end
 
-    entry.value = optval
+    if type(entry.value) == 'table' then
+      table.insert(entry.value, optval)
+    else
+      entry.value = optval
+    end
   end
 
   -- missing any required arguments, or too many?


### PR DESCRIPTION
This allows an option to be specified multiple times on the command-line and have the option values stored in a list in the order that they are specified on the command-line. Just pass `{}` as the default value to an option, and the option key will be populated with a list of all values specified for that key.
```lua
local cli = require 'cliargs'
cli:add_option("--append-value=VALUE", "values what will be added to a list", {})
local cliArgs = cli:parse()
local list = {}
for k,v in ipairs(cliArgs['append-value']) do
  table.insert(list, v)
  print(k, v)
end
```
```
$ lua myapp.lua --append-value=value1 --append-value=value2 --append-value=value3
1   value1
2   value2
3   value3
```