### PR TITLE
Add `--` as marker for end of options

### DIFF
--- a/spec/cliargs_parsing_spec.lua
+++ b/spec/cliargs_parsing_spec.lua
@@ -202,12 +202,24 @@ describe("Testing cliargs library parsing commandlines", function()
     assert.is.falsy(result)
   end)
 
-  it("tests optionals + required, no optionals and to many required provided, ", function()
+  it("tests optionals + required, no optionals and too many required provided, ", function()
     _G.arg = { "some_file", "some_other_file" }
     populate_required(cli)
     populate_optionals(cli)
     result = cli:parse(true --[[no print]])
     assert.is.falsy(result)
+  end)
+
+  it("tests optionals + required + optarg, '--' as end of optionals", function()
+    _G.arg = { "--verbose", "--", "--input", "-d" }
+    populate_required(cli)
+    populate_optarg(1)
+    local expected = populate_flags(cli)
+    expected.INPUT = "--input"
+    expected.OUTPUT = "-d"
+    expected.verbose = true
+    local result = cli:parse()
+    assert.is.same(expected, result)
   end)
 
   it("tests bad short-key notation, -x=VALUE", function()

--- a/src/cliargs.lua
+++ b/src/cliargs.lua
@@ -307,6 +307,11 @@ function cli:parse(noprint, dump)
       break   -- no optional prefix, so options are done
     end
 
+    if opt == "--" then
+      table.remove(args, 1)
+      break   -- end of options
+    end
+
     if optkey:sub(-1,-1) == "=" then  -- check on a blank value eg. --insert=
       optval = ""
       optkey = optkey:sub(1,-2)


### PR DESCRIPTION
This allows for passing positional arguments that start with a `-`.
```lua
local cli = require 'cliargs'
cli:add_argument('VALUE1', 'first integer')
cli:add_argument('VALUE2', 'second integer')
cli:add_option('--verbose', 'display verbose output')
local args = cli:parse()
local val1 = tonumber(args.VALUE1)
local val2 = tonumber(args.VALUE2)
print(string.format("%d + %d = %d", val1, val2, val1+val2))
```
```
$ lua myapp.lua --verbose -- -1 5
-1 + 5 = 4
```
Specifying a `--` stops parsing options and starts parsing positional arguments.
