### PR TITLE
Add callback function for options parsing

### DIFF
--- a/example.lua
+++ b/example.lua
@@ -9,6 +9,14 @@ Try this file with the following commands lines;
 
 local cli = require "cliargs"
 
+local function print_version(key, value, altkey)
+  -- this is called when the flag -v or --version is set
+  if key == 'version' then
+    print("cli_example.lua: version 1.2.1")
+    os.exit(0)
+  end
+end
+
 cli:set_name("cli_example.lua")
 
 -- Required arguments:
@@ -26,8 +34,8 @@ cli:set_name("cli_example.lua")
 -- Flags: a flag is a boolean option. Defaults to false
   -- A flag with short-key notation only
   cli:add_flag("-d", "script will run in DEBUG mode")
-  -- A flag with both the short-key and --expanded-key notations
-  cli:add_flag("-v, --version", "prints the program's version and exits")
+  -- A flag with both the short-key and --expanded-key notations, and callback function
+  cli:add_flag("-v, --version", "prints the program's version and exits", print_version)
   -- A flag with --expanded-key notation only
   cli:add_flag("--verbose", "the script output will be very verbose")
 
@@ -43,7 +51,7 @@ end
 -- upon successful parsing cliargs will delete itslef to free resources
 -- for k,item in pairs(args) do print(k .. " => " .. tostring(item)) end
 
--- checking for flags: is -v or --version set?
+-- checking for flags: is -v set?
 if args["v"] then
   return print("cli_example.lua: version 1.2.1")
 end

--- a/spec/cliargs_parsing_spec.lua
+++ b/spec/cliargs_parsing_spec.lua
@@ -265,4 +265,50 @@ describe("Testing cliargs library parsing commandlines", function()
     assert(type(err) == "string", "Expected an error string")
   end)
 
+  describe("Tests parsing with callback", function()
+    local cb = {}
+
+    local function callback(key, value, altkey)
+        cb.key, cb.value, cb.altkey = key, value, altkey
+    end
+
+    before_each(function()
+      cb = {}
+    end)
+
+    it("tests short-key option", function()
+      _G.arg = { "-k", "myvalue" }
+      cli:add_option("-k, --long-key=VALUE", "key descriptioin", "", callback)
+      local expected = { k = "myvalue", ["long-key"] = "myvalue" }
+      local result = cli:parse()
+      assert.are.same(expected, result)
+      assert.are.equal(cb.key, "k")
+      assert.are.equal(cb.value, "myvalue")
+      assert.are.equal(cb.altkey, "long-key")
+    end)
+
+    it("tests expanded-key option", function()
+      _G.arg = { "--long-key", "val" }
+      cli:add_option("-k, --long-key=VALUE", "key descriptioin", "", callback)
+      local expected = { k = "val", ["long-key"] = "val" }
+      local result = cli:parse()
+      assert.are.same(expected, result)
+      assert.are.equal(cb.key, "long-key")
+      assert.are.equal(cb.value, "val")
+      assert.are.equal(cb.altkey, "k")
+    end)
+
+    it("tests expanded-key flag with not short-key", function()
+      _G.arg = { "--version" }
+      cli:add_flag("--version", "prints the version and exits", callback)
+      local expected = { version = true }
+      local result = cli:parse()
+      assert.are.same(expected, result)
+      assert.are.equal(cb.key, "version")
+      assert.are.equal(cb.value, true)
+      assert.are.equal(cb.altkey, nil)
+    end)
+
+  end)
+
 end)

--- a/src/cliargs.lua
+++ b/src/cliargs.lua
@@ -139,7 +139,7 @@ end
 ---
 --- ### Parameters
 --- 1. **key**: the argument's "name" that will be displayed to the user
---- 1. **desc**: a description of the argument
+--- 2. **desc**: a description of the argument
 ---
 --- ### Usage example
 --- The following will parse the argument (if specified) and set its value in `args["root"]`:
@@ -162,9 +162,9 @@ end
 ---
 --- ### Parameters
 --- 1. **key**: the argument's "name" that will be displayed to the user
---- 1. **desc**: a description of the argument
---- 1. **default**: *optional*; specify a default value (the default is "")
---- 1. **maxcount**: *optional*; specify the maximum number of occurences allowed (default is 1)
+--- 2. **desc**: a description of the argument
+--- 3. **default**: *optional*; specify a default value (the default is "")
+--- 4. **maxcount**: *optional*; specify the maximum number of occurences allowed (default is 1)
 ---
 --- ### Usage example
 --- The following will parse the argument (if specified) and set its value in `args["root"]`:
@@ -192,13 +192,14 @@ end
 --- if the 2nd notation is used then a value can be defined after an `=` (`'-key, --expanded-key=VALUE'`).
 --- As a final option it is possible to only use the expanded key (eg. `'--expanded-key'`) both with and
 --- without a value specified.
---- 1. **desc**: a description for the argument to be shown in --help
---- 1. **default**: *optional*; specify a default value (the default is "")
+--- 2. **desc**: a description for the argument to be shown in --help
+--- 3. **default**: *optional*; specify a default value (the default is "")
+--- 4. **callback**: *optional*; specify a function to call when this option is parsed (the default is nil)
 ---
 --- ### Usage example
 --- The following option will be stored in `args["i"]` and `args["input"]` with a default value of `my_file.txt`:
 --- `cli:add_option("-i, --input=FILE", "path to the input file", "my_file.txt")`
-function cli:add_opt(key, desc, default)
+function cli:add_opt(key, desc, default, callback)
 
   -- parameterize the key if needed, possible variations:
   -- 1. -key
@@ -212,6 +213,7 @@ function cli:add_opt(key, desc, default)
 
   assert(type(key) == "string" and type(desc) == "string", "Key and description are mandatory arguments (Strings)")
   assert(type(default) == "string" or default == nil or default == false, "Default argument: expected a string or nil")
+  assert(type(callback) == "function" or callback == nil or (getmetatable(callback) or {}).__call, "Callback argument: expected a function or nil")
 
   local k, ek, v = disect(key)
 
@@ -237,6 +239,7 @@ function cli:add_opt(key, desc, default)
     label = key,
     flag = (default == false),
     value = default,
+    callback = callback,
   }
 
   table.insert(self.optional, entry)
@@ -249,9 +252,10 @@ end
 ---
 --- ### Parameters
 -- 1. **key**: the argument's key
--- 1. **desc**: a description of the argument to be displayed in the help listing
-function cli:add_flag(key, desc)
-  self:add_opt(key, desc, false)
+-- 2. **desc**: a description of the argument to be displayed in the help listing
+-- 4. **callback**: *optional*; specify a function to call when this flag is parsed (the default is nil)
+function cli:add_flag(key, desc, callback)
+  self:add_opt(key, desc, false, callback)
 end
 
 --- Parses the arguments found in #arg and returns a table with the populated values.
@@ -260,7 +264,7 @@ end
 ---
 --- ### Parameters
 --- 1. **noprint**: set this flag to prevent any information (error or help info) from being printed
---- 1. **dump**: set this flag to dump the parsed variables for debugging purposes, alternatively
+--- 2. **dump**: set this flag to dump the parsed variables for debugging purposes, alternatively
 --- set the first option to --__DUMP__ (option with 2 trailing and leading underscores) to dump at runtime.
 ---
 --- ### Returns
@@ -351,6 +355,12 @@ function cli:parse(noprint, dump)
     end
 
     entry.value = optval
+
+    if entry.callback then
+      local altkey = entry.key
+      if optkey == entry.key then altkey = entry.expanded_key end
+      entry.callback(optkey, optval, altkey)
+    end
   end
 
   -- missing any required arguments, or too many?


### PR DESCRIPTION
This allows a callback function to be passed to `cli:add_option` or `cli:add_flag`.  The callback function is called when the option or flag is parsed by `cliargs`.
```lua
local out= {}

local function printVersion(key, value, altkey)
  print('myapp version 1.0')
  os.exit(0)
end

local function setOutFile(key, value, altkey)
  out.key = key
  opts.altkey = altkey
  out.value= value
end

local cli = require 'cliargs'
cli:set_name('myapp')
cli:add_flag('-v, --version', 'print the version and exit', printVersion)
cli:add_option('-o, --output=FILE', 'specify output file', '/dev/stdout',  setOutFile)

local args = cli:parse()

print('args.o: ' .. args.o)
print('out.key: ' .. out.key)
print('out.altkey: ' .. out.altkey)
print('out.value: ' .. outfile)
```
```
$ lua myapp.lua --output myfile
args.o: myfile
out.key: output
out.altkey: o
out.value: myfile
```
```
$ lua myapp.lua -o myfile
args.o: myfile
out.key: o
out.altkey: output
out.value: myfile
```
```
$ lua myapp.lua --version
myapp version 1.0
```

Also fixes issue #29