### PR TITLE
Returning an error code when the argument parsing fails

### DIFF
--- a/example.lua
+++ b/example.lua
@@ -36,7 +36,7 @@ local args = cli:parse_args()
 
 if not args then
   -- something wrong happened and an error was printed
-  return
+  os.exit(1)
 end
 
 -- argument parsing was successful, arguments can be found in `args`


### PR DESCRIPTION
It is good practice to use the appropriate exit code if the application returns an error. By just using `return` the application will exit with error code `0` even if the arguments supplied are wrong. By invoking `os.exit(1)`, the application will return an error code `1` instead.