### PR TITLE
Modify cli:parse to take arg as an input

### DIFF
--- a/examples/00_general.lua
+++ b/examples/00_general.lua
@@ -32,7 +32,7 @@ cli:set_name("cli_example.lua")
   cli:add_flag("--verbose", "the script output will be very verbose")
 
 -- Parses from _G['arg']
-local args = cli:parse_args()
+local args = cli:parse(arg)
 
 if not args then
   -- something wrong happened and an error was printed

--- a/spec/cliargs_methods_spec.lua
+++ b/spec/cliargs_methods_spec.lua
@@ -1,7 +1,7 @@
 
 -- some helper stuff for debugging
 local quoted = function(s)
-  return "'" .. tostring(s) .. "'" 
+  return "'" .. tostring(s) .. "'"
 end
 local dump = function(t)
   print(" ============= Dump " .. tostring(t) .. " =============")
@@ -42,7 +42,7 @@ describe("Testing cliargs library methods/functions", function()
     it("tests the private split() function", function()
       -- takes: str, split-char
       local expected, result
-      
+
       result = cli.split("hello,world",",")
       expected = {"hello", "world"}
       assert.is.same(result, expected)
@@ -65,7 +65,7 @@ describe("Testing cliargs library methods/functions", function()
       -- takes: text, size, padding
       local text = "123456789 123456789 123456789!"
       local expected, result
-      
+
       result = cli.wordwrap(text, 10)
       expected = "123456789\n123456789\n123456789!"
       assert.is.same(result, expected)
@@ -92,7 +92,7 @@ describe("Testing cliargs library methods/functions", function()
     end)
 
   end)   -- private functions
-  
+
   describe("testing public functions", function()
 
     setup(function()
@@ -104,7 +104,7 @@ describe("Testing cliargs library methods/functions", function()
     teardown(function()
       _G._TEST = nil
     end)
-    
+
     before_each(function()
       cli.optional = {}
       cli.required = {}
@@ -120,7 +120,7 @@ describe("Testing cliargs library methods/functions", function()
       assert.are.equal(cli.required[1].key, key)
       assert.are.equal(cli.required[1].desc, desc)
     end)
-    
+
     it("tests add_opt() with short-key", function()
       -- takes: key, descr, default
       local key, desc, default = "-i", "thedescription", "default"
@@ -131,7 +131,7 @@ describe("Testing cliargs library methods/functions", function()
       assert.are.equal(cli.optional[1].flag, true)
       assert.are.equal(cli.optional[1].default, false) -- no value = flag type option, hence false
     end)
-    
+
     it("tests add_opt() with short-key & value", function()
       -- takes: key, descr, default
       local key, desc, default = "-i VALUE", "thedescription", "default"
@@ -142,7 +142,7 @@ describe("Testing cliargs library methods/functions", function()
       assert.are.equal(cli.optional[1].flag, false)
       assert.are.equal(cli.optional[1].default, default)
     end)
-    
+
     it("tests add_opt() with short + expanded-key", function()
       -- takes: key, descr, default
       local key, desc, default = "-i, --insert", "thedescription", "default"
@@ -153,7 +153,7 @@ describe("Testing cliargs library methods/functions", function()
       assert.are.equal(cli.optional[1].flag, true)
       assert.are.equal(cli.optional[1].default, false) -- no value = flag type option, hence false
     end)
-    
+
     it("tests add_opt() with short + expanded-key & value", function()
       -- takes: key, descr, default
       local key, desc, default = "-i, --insert=VALUE", "thedescription", "default"
@@ -164,7 +164,7 @@ describe("Testing cliargs library methods/functions", function()
       assert.are.equal(cli.optional[1].flag, false)
       assert.are.equal(cli.optional[1].default, default)
     end)
-    
+
     it("tests add_opt() with only expanded-key", function()
       -- takes: key, descr, default
       local key, desc, default = "--insert", "thedescription", "default"
@@ -175,7 +175,7 @@ describe("Testing cliargs library methods/functions", function()
       assert.are.equal(cli.optional[1].flag, true)
       assert.are.equal(cli.optional[1].default, false) -- no value = flag type option, hence false
     end)
-    
+
     it("tests add_opt() with only expanded-key & value", function()
       -- takes: key, descr, default
       local key, desc, default = "--insert=VALUE", "thedescription", "default"
@@ -186,7 +186,7 @@ describe("Testing cliargs library methods/functions", function()
       assert.are.equal(cli.optional[1].flag, false)
       assert.are.equal(cli.optional[1].default, default)
     end)
-    
+
     it("tests add_opt() with short and expanded-key, no comma between them", function()
       -- takes: key, descr, default
       local key, desc, default = "-i --insert=VALUE", "thedescription", "default"
@@ -194,7 +194,7 @@ describe("Testing cliargs library methods/functions", function()
       assert.are.equal(cli.optional[1].key, "i")
       assert.are.equal(cli.optional[1].expanded_key, "insert")
     end)
-      
+
     it("tests add_flag() for setting default value", function()
       -- takes: key, descr
       local key, desc = "-i, --insert", "thedescription"
@@ -216,7 +216,7 @@ describe("Testing cliargs library methods/functions", function()
       assert.are.equal(cli.required[1].key, key) -- make sure it got added
       assert.is.error(function() cli:add_arg(key, desc) end) -- this should blow up
     end)
-    
+
     it("tests add_opt() with a duplicate argument", function()
       -- takes: key, descr
       local key, desc, default = "-i", "thedescription", "default"
@@ -225,11 +225,11 @@ describe("Testing cliargs library methods/functions", function()
       --assert.are.equal(cli.optional[1].expanded_key, "")
       assert.is.error(function() cli:add_opt(key, desc, default) end) -- this should blow up
     end)
-    
+
     describe("testing the 'noprint' options", function()
 
       local old_print, touched
-    
+
       setup(function()
         old_print = print
         local interceptor = function(...)
@@ -238,7 +238,7 @@ describe("Testing cliargs library methods/functions", function()
         end
         print = interceptor
       end)
-      
+
       teardown(function()
         print = (old_print or print)
       end)
@@ -246,7 +246,7 @@ describe("Testing cliargs library methods/functions", function()
       before_each(function()
         touched = nil
       end)
-      
+
       after_each(function()
       end)
 
@@ -258,21 +258,21 @@ describe("Testing cliargs library methods/functions", function()
         assert.is.equal(type(res), "string")
         assert.is.equal(nil, touched)
       end)
-      
+
       it("tests whether a parsing error through cli_error() does not print anything, if noprint is set", function()
         -- generate a parse error
         local key, desc = "ARGUMENT", "thedescription"
         cli:add_opt(key, desc)
         local noprint = true
-        _G.arg = {"arg1", "arg2", "arg3", "arg4"} -- should fail for too many arguments
-        local res, err = cli:parse(noprint)
+        local args = {"arg1", "arg2", "arg3", "arg4"} -- should fail for too many arguments
+        local res, err = cli:parse(args, noprint)
         assert.is.equal(nil, res)
         assert.is.equal(type(err), "string")
         assert.is.equal(nil, touched)
       end)
-      
+
     end)
 
   end)   -- public functions
-  
+
 end)

--- a/spec/cliargs_parsing_spec.lua
+++ b/spec/cliargs_parsing_spec.lua
@@ -63,35 +63,46 @@ describe("Testing cliargs library parsing commandlines", function()
   end)
 
   it("tests no arguments set, nor provided", function()
-    result = cli:parse()
+    local args = {}
+    result = cli:parse(args)
     assert.are.same(result, {})
   end)
 
+  it("tests uses global arg if arguments set not passed in", function()
+    _G.arg = { "--version" }
+    defaults = populate_flags(cli)
+    defaults.v = true
+    defaults.version = true
+    result = cli:parse(true --[[no print]])
+    assert.are.same(result, defaults)
+  end)
+
   it("tests only optionals, nothing provided", function()
+    local args = {}
     defaults = populate_optionals(cli)
-    result = cli:parse()
+    result = cli:parse(args)
     assert.are.same(result, defaults)
   end)
 
   it("tests only required, all provided", function()
-    _G.arg = { "some_file" }
+    local args = { "some_file" }
     populate_required(cli)
-    result = cli:parse()
+    result = cli:parse(args)
     assert.are.same(result, { ["INPUT"] = "some_file" })
   end)
 
   it("tests only optionals, all provided", function()
-    _G.arg = { "-o", "/dev/cdrom", "--compress=lzma" }
+    local args = { "-o", "/dev/cdrom", "--compress=lzma" }
     populate_optionals(cli)
-    result = cli:parse()
+    result = cli:parse(args)
     assert.are.same(result, { o = "/dev/cdrom", c = "lzma", compress = "lzma" })
   end)
 
   it("tests optionals + required, all provided", function()
-    _G.arg = { "-o", "/dev/cdrom", "-c", "lzma", "some_file" }
+    local args = { "-o", "/dev/cdrom", "-c", "lzma", "some_file" }
     populate_required(cli)
     populate_optionals(cli)
-    result = cli:parse()
+    result = cli:parse(args)
     assert.are.same(result, {
       o = "/dev/cdrom",
       c = "lzma", compress = "lzma",
@@ -100,45 +111,45 @@ describe("Testing cliargs library parsing commandlines", function()
   end)
 
   it("tests optional using -short-key notation", function()
-    _G.arg = { "-c", "lzma" }
+    local args = { "-c", "lzma" }
     defaults = populate_optionals(cli)
     defaults.c = "lzma"
     defaults.compress = "lzma"
 
-    result = cli:parse()
+    result = cli:parse(args)
     assert.are.same(result, defaults)
   end)
 
   it("tests optional using --expanded-key notation, --x=VALUE", function()
-    _G.arg = { "--compress=lzma" }
+    local args = { "--compress=lzma" }
     defaults = populate_optionals(cli)
     defaults.c = "lzma"
     defaults.compress = "lzma"
 
-    result = cli:parse()
+    result = cli:parse(args)
 
     assert.are.same(result, defaults)
   end)
 
   it("tests optional using alternate --expanded-key notation, --x VALUE", function()
-    _G.arg = { "--compress", "lzma" }
+    local args = { "--compress", "lzma" }
     defaults = populate_optionals(cli)
     defaults.c = "lzma"
     defaults.compress = "lzma"
 
-    result = cli:parse()
+    result = cli:parse(args)
 
     assert.are.same(result, defaults)
   end)
 
   describe("multiple values for a single key", function()
     it("should work for keys that explicitly permit it", function()
-      _G.arg = { "--key", "value1", "-k", "value2", "--key=value3" }
+      local args = { "--key", "value1", "-k", "value2", "--key=value3" }
       cli:add_option("-k, --key=VALUE", "key that can be specified multiple times", {})
       defaults = { key = {"value1", "value2", "value3"} }
       defaults.k = defaults.key
 
-      result = cli:parse()
+      result = cli:parse(args)
 
       assert.are.same(result, defaults)
     end)
@@ -161,73 +172,73 @@ describe("Testing cliargs library parsing commandlines", function()
   end)
 
   it("tests flag using -short-key notation", function()
-    _G.arg = { "-v" }
+    local args = { "-v" }
     defaults = populate_flags(cli)
     defaults.v = true
     defaults.version = true
-    result = cli:parse()
+    result = cli:parse(args)
     assert.are.same(result, defaults)
   end)
 
   it("tests flag using --expanded-key notation", function()
-    _G.arg = { "--version" }
+    local args = { "--version" }
     defaults = populate_flags(cli)
     defaults.v = true
     defaults.version = true
-    result = cli:parse()
+    result = cli:parse(args)
     assert.are.same(result, defaults)
   end)
 
   it("tests sk-only flag", function()
-    _G.arg = { "-d" }
+    local args = { "-d" }
     defaults = populate_flags(cli)
     defaults.d = true
-    result = cli:parse()
+    result = cli:parse(args)
     assert.are.same(result, defaults)
   end)
 
   it("tests ek-only flag", function()
-    _G.arg = { "--verbose" }
+    local args = { "--verbose" }
     defaults = populate_flags(cli)
     defaults.verbose = true
-    result = cli:parse()
+    result = cli:parse(args)
     assert.are.same(result, defaults)
   end)
 
   it("tests optionals + required, no optionals and to little required provided, ", function()
-    _G.arg = { }
+    local args = { }
     populate_required(cli)
     populate_optionals(cli)
-    result = cli:parse(true --[[no print]])
+    result = cli:parse(args, true --[[no print]])
     assert.is.falsy(result)
   end)
 
   it("tests optionals + required, no optionals and to many required provided, ", function()
-    _G.arg = { "some_file", "some_other_file" }
+    local args = { "some_file", "some_other_file" }
     populate_required(cli)
     populate_optionals(cli)
-    result = cli:parse(true --[[no print]])
+    result = cli:parse(args, true --[[no print]])
     assert.is.falsy(result)
   end)
 
   it("tests bad short-key notation, -x=VALUE", function()
-    _G.arg = { "-o=some_file" }
+    local args = { "-o=some_file" }
     populate_optionals(cli)
-    result = cli:parse(true --[[no print]])
+    result = cli:parse(args, true --[[no print]])
     assert.is.falsy(result)
   end)
 
   it("tests unknown option", function()
-    _G.arg = { "--foo=bar" }
+    local args = { "--foo=bar" }
     populate_optionals(cli)
-    result = cli:parse(true --[[no print]])
+    result = cli:parse(args, true --[[no print]])
     assert.is.falsy(result)
   end)
 
   it("tests unknown flag", function()
-    _G.arg = { "--foo" }
+    local args = { "--foo" }
     populate_optionals(cli)
-    result = cli:parse(true --[[no print]])
+    result = cli:parse(args, true --[[no print]])
     assert.is.falsy(result)
   end)
 
@@ -244,39 +255,39 @@ describe("Testing cliargs library parsing commandlines", function()
   end)
 
   it("tests optarg only, values, multiple allowed", function()
-    _G.arg = {"/output1/", "/output2/"}
+    local args = {"/output1/", "/output2/"}
     defaults = populate_optarg(3)
-    result = cli:parse(true --[[no print]])
+    result = cli:parse(args, true --[[no print]])
     assert.is.same(result, { OUTPUT = {"/output1/", "/output2/"}})
   end)
 
   it("tests optarg only, values, 1 allowed", function()
-    _G.arg = {"/output/"}
+    local args = {"/output/"}
     defaults = populate_optarg(1)
-    result = cli:parse(true --[[no print]])
+    result = cli:parse(args, true --[[no print]])
     assert.is.same(result, { OUTPUT = "/output/" })
   end)
 
   it("tests optarg only, too many values", function()
-    _G.arg = {"/output1/", "/output2/"}
+    local args = {"/output1/", "/output2/"}
     defaults = populate_optarg(1)
-    result = cli:parse(true --[[no print]])
+    result = cli:parse(args, true --[[no print]])
     assert.is.same(result, nil)
   end)
 
   it("tests optarg only, too many values", function()
-    _G.arg = {"/input/", "/output/"}
+    local args = {"/input/", "/output/"}
     populate_required()
     populate_optarg(1)
-    result = cli:parse(true --[[no print]])
+    result = cli:parse(args, true --[[no print]])
     assert.is.same(result, { INPUT = "/input/", OUTPUT = "/output/" })
   end)
 
   it("tests clearing the default of an optional", function()
     local err
-    _G.arg = { "--compress=" }
+    local args = { "--compress=" }
     populate_optionals(cli)
-    result, err = cli:parse(true --[[no print]])
+    result, err = cli:parse(args, true --[[no print]])
     assert.are.equal(nil,err)
     -- are_not.equal is not working when comparing against a nil as
     -- of luassert-1.2-1, using is.truthy instead for now
@@ -286,10 +297,10 @@ describe("Testing cliargs library parsing commandlines", function()
   end)
 
   it("tests parsing a flag (expanded-key) with a value provided", function()
-    _G.arg = { "--verbose=something" }
+    local args = { "--verbose=something" }
     defaults = populate_flags(cli)
     defaults.verbose = true
-    local result, err = cli:parse(true --[[no print]])
+    local result, err = cli:parse(args, true --[[no print]])
     assert(result == nil, "Adding a value to a flag must error out")
     assert(type(err) == "string", "Expected an error string")
   end)

--- a/src/cliargs.lua
+++ b/src/cliargs.lua
@@ -266,6 +266,7 @@ end
 --- *Aliases: `parse_args`*
 ---
 --- ### Parameters
+--- 1. **arguments**: set this to arg
 --- 1. **noprint**: set this flag to prevent any information (error or help info) from being printed
 --- 1. **dump**: set this flag to dump the parsed variables for debugging purposes, alternatively
 --- set the first option to --__DUMP__ (option with 2 trailing and leading underscores) to dump at runtime.
@@ -273,10 +274,14 @@ end
 --- ### Returns
 --- 1. a table containing the keys specified when the arguments were defined along with the parsed values,
 --- or nil + error message (--help option is considered an error and returns nil + help message)
-function cli:parse(noprint, dump)
-  arg = arg or {}
+function cli:parse(arguments, noprint, dump)
+  if type(arguments) ~= "table" then
+    -- optional 'arguments' was not provided, so shift remaining arguments
+    noprint, dump, arguments = arguments, noprint, nil
+  end
+  local arguments = arguments or arg or {}
   local args = {}
-  for k,v in pairs(arg) do args[k] = v end  -- copy global args local
+  for k,v in pairs(arguments) do args[k] = v end  -- copy args local
 
   -- starts with --help? display the help listing and abort!
   if args[1] and (args[1] == "--help" or args[1] == "-h") then


### PR DESCRIPTION
This modifies the `cli:parse` function to take a table of command line arguments as the first parameter to the function. If an argument list is not is not passed in, it will default to the global `arg`.

This allows `cli:parse` to be more testable without having to clobber the global `arg` variable in the specs. It also enables an application to pass command line arguments to `cli:parse` without clobbering `_G.arg` when forwarding options to another file.  You can still call `cli:parse()` without any arguments and it will default to the global `arg`.
