### PR TITLE
Set default option value to nil if no default is specified

### DIFF
--- a/spec/cliargs_methods_spec.lua
+++ b/spec/cliargs_methods_spec.lua
@@ -182,7 +182,7 @@ describe("Testing cliargs library methods/functions", function()
           assert.are.equal(cli.optional[1].key, "i")
           assert.are.equal(cli.optional[1].desc, desc)
           assert.are.equal(cli.optional[1].flag, true)
-          assert.are.equal(cli.optional[1].default, false) -- no value = flag type option, hence false
+          assert.are.equal(cli.optional[1].default, nil) -- no value = flag type option, hence nil
         end)
 
         it("should work with a short-key that is longer than 1 character", function()
@@ -193,7 +193,7 @@ describe("Testing cliargs library methods/functions", function()
           assert.are.equal(cli.optional[1].key, "Wno-unsigned")
           assert.are.equal(cli.optional[1].desc, desc)
           assert.are.equal(cli.optional[1].flag, true)
-          assert.are.equal(cli.optional[1].default, false) -- no value = flag type option, hence false
+          assert.are.equal(cli.optional[1].default, nil) -- no value = flag type option, hence nil
         end)
 
         it("should work with only expanded-key", function()
@@ -203,7 +203,7 @@ describe("Testing cliargs library methods/functions", function()
           assert.are.equal(cli.optional[1].expanded_key, "insert")
           assert.are.equal(cli.optional[1].desc, desc)
           assert.are.equal(cli.optional[1].flag, true)
-          assert.are.equal(cli.optional[1].default, false) -- no value = flag type option, hence false
+          assert.are.equal(cli.optional[1].default, nil) -- no value = flag type option, hence nil
         end)
 
         it("should work with combined short + expanded-key", function()
@@ -214,7 +214,7 @@ describe("Testing cliargs library methods/functions", function()
           assert.are.equal(cli.optional[1].expanded_key, "insert")
           assert.are.equal(cli.optional[1].desc, desc)
           assert.are.equal(cli.optional[1].flag, true)
-          assert.are.equal(cli.optional[1].default, false) -- no value = flag type option, hence false
+          assert.are.equal(cli.optional[1].default, nil) -- no value = flag type option, hence nil
         end)
       end)
     end)
@@ -224,7 +224,7 @@ describe("Testing cliargs library methods/functions", function()
       local key, desc = "-i, --insert", "thedescription"
       cli:add_flag(key, desc)
       assert.are.equal(cli.optional[1].flag, true)
-      assert.are.equal(cli.optional[1].default, false)  -- boolean because its a flag
+      assert.are.equal(cli.optional[1].default, nil)
     end)
 
     it("tests add_flag() to error-out when providing a value", function()

--- a/spec/cliargs_parsing_spec.lua
+++ b/spec/cliargs_parsing_spec.lua
@@ -42,7 +42,7 @@ local function populate_flags()
   cli:add_flag("-d", "script will run in DEBUG mode")
   cli:add_flag("--verbose", "the script output will be very verbose")
 
-  return { d = false, v = false, version = false, verbose = false }
+  return { d = nil, v = nil, version = nil, verbose = nil }
 end
 
 -- start tests

--- a/src/cliargs.lua
+++ b/src/cliargs.lua
@@ -193,7 +193,7 @@ end
 --- As a final option it is possible to only use the expanded key (eg. `'--expanded-key'`) both with and
 --- without a value specified.
 --- 2. **desc**: a description for the argument to be shown in --help
---- 3. **default**: *optional*; specify a default value (the default is "")
+--- 3. **default**: *optional*; specify a default value (the default is nil)
 --- 4. **callback**: *optional*; specify a function to call when this option is parsed (the default is nil)
 ---
 --- ### Usage example
@@ -241,8 +241,7 @@ function cli:add_opt(key, desc, default, callback)
   end
 
   -- set defaults
-  if v == nil then default = false end   -- no value, so its a flag
-  if default == nil then default = "" end
+  if v == nil then default = nil end   -- no value, set it's a flag, so set default to nil
 
   -- below description of full entry record, nils included for reference
   local entry = {
@@ -251,7 +250,7 @@ function cli:add_opt(key, desc, default, callback)
     desc = desc,
     default = default,
     label = key,
-    flag = (default == false),
+    flag = (v == nil), -- no value, so it's a flag
     value = default,
     callback = callback,
   }

--- a/src/cliargs.lua
+++ b/src/cliargs.lua
@@ -163,7 +163,7 @@ end
 --- ### Parameters
 --- 1. **key**: the argument's "name" that will be displayed to the user
 --- 2. **desc**: a description of the argument
---- 3. **default**: *optional*; specify a default value (the default is "")
+--- 3. **default**: *optional*; specify a default value (the default is nil)
 --- 4. **maxcount**: *optional*; specify the maximum number of occurences allowed (default is 1)
 ---
 --- ### Usage example
@@ -172,8 +172,7 @@ end
 --- The value returned will be a table with at least 1 entry and a maximum of 2 entries
 function cli:optarg(key, desc, default, maxcount)
   assert(type(key) == "string" and type(desc) == "string", "Key and description are mandatory arguments (Strings)")
-  default = default or ""
-  assert(type(default) == "string", "Default value must either be omitted or be a string")
+  assert(type(default) == "string" or default == nil, "Default value must either be omitted or be a string")
   maxcount = maxcount or 1
   maxcount = tonumber(maxcount)
   assert(maxcount and maxcount>0 and maxcount<1000,"Maxcount must be a number from 1 to 999")


### PR DESCRIPTION
This sets the default option value to be `nil` when it is not specified by the user.  This way any options that are not set on the command-line and do not have a default will have a `nil` value in the table returned by `cli:parse`.

This way you can do
```lua
if cliArg.option then
  ...
end
```
instead of
```lua
if cliArg.option ~= "" then
  ...
end
```
Passing `""` is also legal on the command-line, so the latter case would be ambiguous as to whether or not the user passed a value to `option` on the command-line.  Furthermore, if you want the default value to be `""`, then you should be explicit about it and pass it in to `cli:add_option`.