### PR TITLE
Fix version string not matching rockspec version

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -13,6 +13,9 @@ function abort {
 [ -z "${GITHUB_REPO}"   ] && abort "Missing GITHUB_REPO env variable."
 
 VERSION=$(grep "version" lua_cliargs-*.rockspec | cut -d' ' -f3 | sed 's/"//g')
+SRC_VERSION=$(grep "_VERSION" src/cliargs.lua | sed -e 's/.*=//' -e 's/.* //' -e 's/"//g')
+
+[ "${VERSION}" != "${SRC_VERSION}" ] && abort "Verion in rockspec does not match source"
 
 # Publish to GitHub
 JSON_PAYLOAD=$(

--- a/src/cliargs.lua
+++ b/src/cliargs.lua
@@ -606,7 +606,7 @@ end
 cli._COPYRIGHT   = "Copyright (C) 2011-2014 Ahmad Amireh"
 cli._LICENSE     = "The code is released under the MIT terms. Feel free to use it in both open and closed software as you please."
 cli._DESCRIPTION = "Commandline argument parser for Lua"
-cli._VERSION     = "cliargs 2.2-0"
+cli._VERSION     = "cliargs 2.3-3"
 
 -- aliases
 cli.add_argument = cli.add_arg


### PR DESCRIPTION
Updated release script to check that the source `_VERSION` string matches the version in the rockspec.