### PR TITLE
Fixed an issue when trying to print help for a nil default option value.

### DIFF
--- a/src/cliargs.lua
+++ b/src/cliargs.lua
@@ -613,7 +613,7 @@ function cli:print_help(noprint)
   end
 
   if self.optargument.maxcount > 0 then
-    append(self.optargument.key, self.optargument.desc .. " (optional, default: " .. self.optargument.default .. ")")
+    append(self.optargument.key, self.optargument.desc .. " (optional, default: " .. tostring(self.optargument.default) .. ")")
   end
 
   if #self.optional > 0 then


### PR DESCRIPTION
I found an issue with the print_help function when the optargument has a nil default value.

My repro was this:
```lua
local cli = require("cliargs")
cli:optarg("foo", "bar")
cli:parse({"--help"})
```