### PR TITLE
Fixing bug in changing key and desc column sizes

### DIFF
--- a/src/cliargs/core.lua
+++ b/src/cliargs/core.lua
@@ -149,7 +149,8 @@ local function create_core()
   ---        The number of columns assigned to the argument descriptions, set to
   ---        0 to auto set the total width to 72.
   function cli:set_colsz(key_cols, desc_cols)
-    colsz = { key_cols or colsz[1], desc_cols or colsz[2] }
+    colsz[1] = key_cols or colsz[1]
+    colsz[2] = desc_cols or colsz[2]
   end
 
   function cli:redefine_default(key, new_default)


### PR DESCRIPTION
This change ensures column width is actually respected.

For an example of usage, see <https://github.com/libertine-linux/cvetool/blob/master/modules/cvetool/commandLineArgumentsParser.lua> which sets column widths based on COLUMNS, terminal presence and terminal width (and uses the values for standard our or standard error, depending on whether help is to be displayed on stdout because -of `-h` or because of an error on stderr) and <https://github.com/libertine-linux/cvetool/blob/master/modules/cvetool/init.lua> for a real program.