### PR TITLE
Add architecture ppc64le to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,20 @@
 language: c
 
+os: linux
+arch:
+ - amd64
+ - ppc64le
+
 env:
   - LUA='Lua 5.1'
   - LUA='Lua 5.2'
   - LUA='Lua 5.3'
   - LUA='LuaJIT 2.0'
+
+jobs:
+  exclude:
+      - arch: ppc64le
+        env: LUA='LuaJIT 2.0'
 
 branches:
   only:


### PR DESCRIPTION
Add support for architecture ppc64le.
This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3
Updated ppc64le arch and excluded env "LuaJIT 2.0" for ppc64le arch since its not supporting same.