### PR TITLE
Add Dependabot for GitHub Actions and pin workflow actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# Keep GitHub Actions up to date with GitHub's Dependabot...
+# https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/secure-your-dependencies/auto-update-actions
+# https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#package-ecosystem
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    groups:
+      github-actions:
+        patterns:
+          - "*"  # Group all Actions updates into a single larger pull request
+    schedule:
+      interval: weekly
+    cooldown:  # https://nesbitt.io/2026/03/04/package-managers-need-to-cool-down.html
+      default-days: 7

--- a/.github/workflows/busted.yml
+++ b/.github/workflows/busted.yml
@@ -12,15 +12,15 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Setup ‘lua’
-        uses: leafo/gh-actions-lua@v10
+        uses: leafo/gh-actions-lua@35bcb06abec04ec87df82e08caa84d545348536e # v10
         with:
           luaVersion: ${{ matrix.luaVersion }}
 
       - name: Setup ‘luarocks’
-        uses: leafo/gh-actions-luarocks@v4
+        uses: leafo/gh-actions-luarocks@e65774a6386cb4f24e293dca7fc4ff89165b64c5 # v4
 
       - name: Setup test dependencies
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,12 +5,12 @@ on: [ push, workflow_dispatch ]
 jobs:
 
   affected:
-    uses: lunarmodules/.github/.github/workflows/list_affected_rockspecs.yml@main
+    uses: lunarmodules/.github/.github/workflows/list_affected_rockspecs.yml@5e21af2b298be5ad6677a4737114db239510d3ce # main
 
   build:
     needs: affected
     if: ${{ needs.affected.outputs.rockspecs }}
-    uses: lunarmodules/.github/.github/workflows/test_build_rock.yml@main
+    uses: lunarmodules/.github/.github/workflows/test_build_rock.yml@5e21af2b298be5ad6677a4737114db239510d3ce # main
     with:
       rockspecs: ${{ needs.affected.outputs.rockspecs }}
 
@@ -27,7 +27,7 @@ jobs:
         ( github.ref_name == 'master' || startsWith(github.ref, 'refs/tags/') ) &&
         needs.affected.outputs.rockspecs
       }}
-    uses: lunarmodules/.github/.github/workflows/upload_to_luarocks.yml@main
+    uses: lunarmodules/.github/.github/workflows/upload_to_luarocks.yml@5e21af2b298be5ad6677a4737114db239510d3ce # main
     with:
       rockspecs: ${{ needs.affected.outputs.rockspecs }}
     secrets:

--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -8,6 +8,6 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - name: Luacheck
-        uses: lunarmodules/luacheck@v1
+        uses: lunarmodules/luacheck@cc089e3f65acdd1ef8716cc73a3eca24a6b845e4 # v1


### PR DESCRIPTION
This PR adds Dependabot support for GitHub Actions and pins workflow action references to commit SHAs.

Commits:
1. Add Dependabot config for GitHub Actions (modeled after terminal.lua)
2. Pin workflow actions to commit SHAs and include version/tag comments after each SHA so Dependabot can update both.