### PR TITLE
add lua 5.4 and 5.5 support

### DIFF
--- a/.github/workflows/busted.yml
+++ b/.github/workflows/busted.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        luaVersion: [ "5.4", "5.3", "5.2", "5.1", "luajit" ] # , "luajit-openresty"
+        luaVersion: [ "5.5", "5.4", "5.3", "5.2", "5.1", "luajit" ] # , "luajit-openresty"
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
@@ -30,7 +30,7 @@ jobs:
           luarocks install busted
           luarocks install dkjson
           luarocks install inifile
-          ${{ matrix.luaVersion != '5.4' && 'luarocks install yaml' || '' }} # https://github.com/lubyk/yaml/issues/7
+          luarocks install lyaml
 
       - name: Replace system cliargs with self
         run: |

--- a/src/cliargs.lua
+++ b/src/cliargs.lua
@@ -2,6 +2,7 @@
 
 local core = require('cliargs.core')()
 local unpack = _G.unpack or table.unpack -- luacheck: compat
+local pack = table.pack or function(...) return { n = select('#', ...), ... } end -- luacheck: compat
 
 local cli = setmetatable({},{ __index = core })
 
@@ -10,9 +11,12 @@ function cli:parse(arguments, no_cleanup)
     cli:cleanup()
   end
 
-  local out = { core.parse(self, arguments) }
+  -- `#` is undefined for a table with a nil hole (e.g. the `nil, err`
+  -- returned on a parsing error), so use pack/unpack's explicit `n`
+  -- instead of relying on the table's border to reconstruct the count.
+  local out = pack(core.parse(self, arguments))
 
-  return unpack(out)
+  return unpack(out, 1, out.n)
 end
 
 -- Clean up the entire module (unload the scripts) as it's expected to be

--- a/src/cliargs/config_loader.lua
+++ b/src/cliargs/config_loader.lua
@@ -113,14 +113,14 @@ return {
 
   --- Load configuration from a YAML file.
   ---
-  --- Requires the "yaml"[1] module to be present on the system. Get it with:
+  --- Requires the "lyaml"[1] module to be present on the system. Get it with:
   ---
-  ---     luarocks install yaml
+  ---     luarocks install lyaml
   ---
-  --- [1] http://doc.lubyk.org/yaml.html
+  --- [1] https://github.com/gvvaughan/lyaml
   from_yaml = function(filepath)
-    local src, config, err
-    local yaml = require 'yaml'
+    local src, err
+    local lyaml = require 'lyaml'
 
     src, err = read_file(filepath)
 
@@ -128,12 +128,12 @@ return {
       return nil, err
     end
 
-    config, err = yaml.load(src)
+    local ok, config_or_err = pcall(lyaml.load, src)
 
-    if not config and err then
-      return nil, err
+    if not ok then
+      return nil, config_or_err
     end
 
-    return config
+    return config_or_err
   end
 }


### PR DESCRIPTION
The luarocks package 'yaml' is unmaintained and restricted to `=< 5.3`. Which cause it to fail on newer versions.

This updates it to the package `lyaml`. This is however a breaking change.

The impact is limited to only the folks that used that yaml functionality, since the yaml package is not a hard dependency specified in the rockspec file. So only users that had `luarocks install yaml` in their builds must swicth to `luarocks install lyaml` (note the extra 'l').

Also fixes an issue where a nil is packed in a table isn't handled properly.

Fixes #76 
Fixes #79 
